### PR TITLE
bring it to par with algolia/scout-extended 3.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,3 +92,8 @@ workflows:
             parameters:
               version: ['8.1', '8.2']
               laravel: ['^10.0']
+      - test:
+          matrix:
+            parameters:
+              version: ['8.2']
+              laravel: ['^11.0']

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [3.1.0](https://github.com/algolia/scout-extended/compare/v3.0.1...v3.1.0) - 2024-03-21
+### Added
+- Laravel 11 support ([#339](https://github.com/algolia/scout-extended/pull/339))
+
+## [3.0.1](https://github.com/algolia/scout-extended/compare/v3.0.0...v3.0.1) - 2024-02-26
+### Added
+- Add configuration option to not use `deleteBy` ([#334](https://github.com/algolia/scout-extended/pull/334))
+
 ## [3.0.0](https://github.com/algolia/scout-extended/compare/v2.1.0...v3.0.0) - 2022-02-06
 ### Added
 - Laravel 10 support ([#320](https://github.com/algolia/scout-extended/pull/320))

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,15 @@
 {
     "name": "algolia/scout-extended",
     "description": "Scout Extended extends Laravel Scout adding algolia-specific features",
-    "keywords": ["laravel", "scout", "algolia", "extended", "search", "places", "analytics"],
+    "keywords": [
+        "laravel",
+        "scout",
+        "algolia",
+        "extended",
+        "search",
+        "places",
+        "analytics"
+    ],
     "license": "MIT",
     "authors": [
         {
@@ -17,11 +25,11 @@
         "php": "^8.0",
         "ext-json": "*",
         "algolia/algoliasearch-client-php": "^3.0.0",
-        "illuminate/console": "^9.0|^10.0",
-        "illuminate/contracts": "^9.0|^10.0",
-        "illuminate/database": "^9.0|^10.0",
-        "illuminate/filesystem": "^9.0|^10.0",
-        "illuminate/support": "^9.0|^10.0",
+        "illuminate/console": "^9.0|^10.0|^11.0",
+        "illuminate/contracts": "^9.0|^10.0|^11.0",
+        "illuminate/database": "^9.0|^10.0|^11.0",
+        "illuminate/filesystem": "^9.0|^10.0|^11.0",
+        "illuminate/support": "^9.0|^10.0|^11.0",
         "laravel/scout": "^9.0|^10.0",
         "riimu/kit-phpencoder": "^2.4"
     },
@@ -32,9 +40,9 @@
         "fakerphp/faker": "^1.13",
         "mockery/mockery": "^1.4",
         "nunomaduro/larastan": "^1.0|^2.0",
-        "orchestra/testbench": "^4.9|^5.9|^6.6|^7.0|^8.0",
+        "orchestra/testbench": "^4.9|^5.9|^6.6|^7.0|^8.0|^9.0",
         "phpstan/phpstan": "^1.3",
-        "phpunit/phpunit": "^8.0|^9.0",
+        "phpunit/phpunit": "^8.0|^9.0|^10.5",
         "laravel/legacy-factories": "^1.1"
     },
     "autoload-dev": {

--- a/src/Managers/EngineManager.php
+++ b/src/Managers/EngineManager.php
@@ -27,7 +27,7 @@ class EngineManager extends BaseEngineManager
      */
     public function createAlgoliaDriver(): AlgoliaEngine
     {
-        UserAgent::addCustomUserAgent('Laravel Scout Extended', '3.0.0');
+        UserAgent::addCustomUserAgent('Laravel Scout Extended', '3.1.0');
 
         return new AlgoliaEngine(SearchClient::create(config('scout.algolia.id'), config('scout.algolia.secret')));
     }


### PR DESCRIPTION
algolia/scout-extended 3.1 brings support for Laravel 11.